### PR TITLE
feat: add basic support for alarm creation and adapting for SQS

### DIFF
--- a/src/core/alarming.ts
+++ b/src/core/alarming.ts
@@ -1,0 +1,152 @@
+import { Alarm, AlarmProps, ComparisonOperator, HorizontalAnnotation, IAlarm, IMetric, TreatMissingData } from '@aws-cdk/aws-cloudwatch';
+import { Construct } from '@aws-cdk/core';
+
+/**
+ * Single alarm customization. If any property is undefined, a default value will be used by the factory.
+ */
+interface AlarmCustomization {
+  /**
+   * number of datapoints to alarm on
+   * @default factory default
+   */
+  readonly datapointsToAlarm?: number;
+  /**
+   * number of periods to evaluate
+   * @default factory default
+   */
+  readonly evaluationPeriods?: number;
+  /**
+   * whether to enable alarm actions
+   * @default factory default
+   */
+  readonly actionsEnabled?: boolean;
+}
+
+/**
+ * Single alarm definition with customization.
+ */
+export interface AlarmDefinition extends AlarmCustomization {
+  /**
+   * alarm threshold
+   */
+  readonly threshold: number;
+}
+
+/**
+ * Properties related to an existing alarm.
+ */
+export interface CreatedAlarm {
+  /**
+   * created alarm
+   */
+  readonly alarm: IAlarm;
+  /**
+   * annotation of the created alarm
+   */
+  readonly annotation: HorizontalAnnotation;
+  /**
+   * the original alarm definition
+   */
+  readonly definition: AlarmDefinition;
+}
+
+/**
+ * Factory that creates alarms on metrics.
+ */
+export interface AlarmFactory {
+  /**
+   * Creates alarms according to the alarm definitions.
+   * @param id alarm identifier (to distinguish alarm from other alarms on the same resource)
+   * @param metric metric to alarm on
+   * @param op comparison operator
+   * @param definitions map of (disambiguator, alarm definition), might be empty or undefined
+   */
+  createAlarms(id: string, metric: IMetric, op: ComparisonOperator, definitions?: Record<string, AlarmDefinition>): CreatedAlarm[];
+}
+
+/**
+ * Props to create DefaultAlarmFactory.
+ */
+export interface DefaultAlarmFactoryProps {
+  /**
+   * global prefix to be used to all alarms created by this factory
+   */
+  readonly prefix: string;
+  /**
+   * default evaluation periods used when there is no custom one
+   */
+  readonly evaluationPeriodsDefault: number;
+  /**
+   * default number of datapoints used when there is no custom one
+   */
+  readonly datapointsToAlarmDefault: number;
+  /**
+   * default action enabled flag used when there is no custom one
+   */
+  readonly actionsEnabledDefault: boolean;
+}
+
+/**
+ * Default implementation of the alarm factory.
+ *
+ */
+export class DefaultAlarmFactory extends Construct implements AlarmFactory {
+  protected readonly prefix: string;
+  protected readonly evaluationPeriodsDefault: number;
+  protected readonly datapointsToAlarmDefault: number;
+  protected readonly actionsEnabledDefault: boolean;
+
+  constructor(scope: Construct, id: string, props: DefaultAlarmFactoryProps) {
+    super(scope, id);
+    this.prefix = props.prefix;
+    this.evaluationPeriodsDefault = props.evaluationPeriodsDefault;
+    this.datapointsToAlarmDefault = props.datapointsToAlarmDefault;
+    this.actionsEnabledDefault = props.actionsEnabledDefault;
+  }
+
+  createAlarms(id: string, metric: IMetric, op: ComparisonOperator, definitions?: Record<string, AlarmDefinition>) {
+    const createdAlarms: CreatedAlarm[] = [];
+    for (let [disambiguator, definition] of Object.entries(definitions ?? {})) {
+      createdAlarms.push(this.createAlarm(id, metric, op, disambiguator, definition));
+    }
+    return createdAlarms;
+  }
+
+  protected createAlarm(id: string, metric: IMetric, op: ComparisonOperator, disambiguator: string, props: AlarmDefinition) {
+    const alarmId = this.alarmId(id, metric, op, disambiguator, props);
+    const alarmName = this.alarmName(id, metric, op, disambiguator, props);
+    const alarmDescription = this.alarmDescription(id, metric, op, disambiguator, props);
+
+    const definition: AlarmProps = {
+      metric,
+      threshold: props.threshold,
+      comparisonOperator: op,
+      treatMissingData: TreatMissingData.MISSING,
+      alarmName,
+      alarmDescription,
+      evaluationPeriods: props.evaluationPeriods ?? this.evaluationPeriodsDefault,
+      datapointsToAlarm: props.datapointsToAlarm ?? this.datapointsToAlarmDefault,
+      actionsEnabled: props.actionsEnabled ?? this.actionsEnabledDefault,
+    };
+
+    const alarm = new Alarm(this, alarmId, definition);
+    const annotation = alarm.toAnnotation();
+
+    return { alarm, definition, annotation };
+  }
+
+  protected alarmId(id: string, _metric: IMetric, _op: ComparisonOperator, disambiguator: string, _props?: AlarmDefinition) {
+    // TODO: will be improved upon later
+    return `${this.prefix}_${id}_${disambiguator}`;
+  }
+
+  protected alarmName(_id: string, _metric: IMetric, _op: ComparisonOperator, _disambiguator: string, _props?: AlarmDefinition) {
+    // TODO: will be improved upon later
+    return undefined;
+  }
+
+  protected alarmDescription(_id: string, _metric: IMetric, _op: ComparisonOperator, _disambiguator: string, _props?: AlarmDefinition) {
+    // TODO: will be improved upon later
+    return undefined;
+  }
+}

--- a/src/core/monitoring.ts
+++ b/src/core/monitoring.ts
@@ -1,27 +1,36 @@
 import { IWidget } from '@aws-cdk/aws-cloudwatch';
-
-/**
- * Base class for monitoring props.
- */
-export interface MonitoringProps {
-  /**
-   * monitoring section title (might be markdown)
-   * @default auto-generated title
-   */
-  readonly titleMarkdown?: string;
-  /**
-   * monitoring section description (might be markdown)
-   * @default empty
-   */
-  readonly descriptionMarkdown?: string;
-}
+import { AlarmFactory } from './alarming';
 
 /**
  * Collection of metrics and alarms, represented by widgets.
+ * Monitoring is not a construct, since we want it to be lightweight.
  */
 export abstract class Monitoring {
   /**
    * Returns the widgets representing this monitoring object.
+   * This should always start with a header widget.
    */
   abstract getWidgets(): IWidget[];
+}
+
+/**
+ * Props to create MonitoringWithAlarms.
+ */
+export interface MonitoringWithAlarmsProps {
+  /**
+   * Factory to be used to create alarms.
+   */
+  readonly alarmFactory: AlarmFactory;
+}
+
+/**
+ * Monitoring with alarm creation support.
+ */
+export abstract class MonitoringWithAlarms extends Monitoring {
+  protected readonly alarmFactory: AlarmFactory;
+
+  protected constructor(props: MonitoringWithAlarmsProps) {
+    super();
+    this.alarmFactory = props.alarmFactory;
+  }
 }

--- a/src/monitoring/aws/sqs/monitoring.ts
+++ b/src/monitoring/aws/sqs/monitoring.ts
@@ -1,23 +1,53 @@
-import { GraphWidget, HorizontalAnnotation, IWidget, Metric } from '@aws-cdk/aws-cloudwatch';
+import { ComparisonOperator, GraphWidget, IWidget, Metric } from '@aws-cdk/aws-cloudwatch';
 import { IQueue } from '@aws-cdk/aws-sqs';
 import { Stack } from '@aws-cdk/core';
-import { Monitoring, MonitoringProps } from '../../../core/monitoring';
+import { AlarmDefinition, CreatedAlarm } from '../../../core/alarming';
+import { MonitoringWithAlarms, MonitoringWithAlarmsProps } from '../../../core/monitoring';
 import { CountAxis, SizeBytesAxis, TimeSecondsAxis } from '../../../widget/axis';
 import { CommonWidgetDimensions } from '../../../widget/constant';
 import { SectionWidget, SectionWidgetProps } from '../../../widget/section';
 import { SqsMetricFactory } from './metrics';
 
 /**
+ * Alarm configuration for an SQS Queue.
+ */
+export interface SqsMonitoringAlarms {
+  /**
+   * alarm when queue size drops below threshold
+   * @default no alarms
+   */
+  readonly alarmOnQueueSizeLow?: Record<string, AlarmDefinition>;
+  /**
+   * alarm when queue size raises above threshold
+   * @default no alarms
+   */
+  readonly alarmOnQueueSizeHigh?: Record<string, AlarmDefinition>;
+  /**
+   * alarm when max message age in the queue raises above threshold
+   * @default no alarms
+   */
+  readonly alarmOnQueueOldestMessageAgeHigh?: Record<string, AlarmDefinition>;
+}
+
+/**
  * Properties to create SqsMonitoring.
  */
-export interface SqsMonitoringProps extends MonitoringProps {
-  queue: IQueue;
+export interface SqsMonitoringProps extends MonitoringWithAlarmsProps {
+  /**
+   * queue to be monitored
+   */
+  readonly queue: IQueue;
+  /**
+   * alarm configuration
+   * @default no alarms
+   */
+  readonly alarms?: SqsMonitoringAlarms;
 }
 
 /**
  * Monitoring of SQS Queue.
  */
-export class SqsMonitoring extends Monitoring {
+export class SqsMonitoring extends MonitoringWithAlarms {
   protected readonly section: SectionWidgetProps;
   protected readonly metrics: SqsMetricFactory;
 
@@ -26,11 +56,12 @@ export class SqsMonitoring extends Monitoring {
   protected readonly oldestMessageAgeMetric: Metric;
   protected readonly messageSizeMetric: Metric;
 
-  protected readonly countAnnotations: HorizontalAnnotation[];
-  protected readonly ageAnnotations: HorizontalAnnotation[];
+  protected readonly lowCountAlarms: CreatedAlarm[];
+  protected readonly highCountAlarms: CreatedAlarm[];
+  protected readonly ageAlarms: CreatedAlarm[];
 
   constructor(props: SqsMonitoringProps) {
-    super();
+    super(props);
 
     this.section = this.headerProps(props);
     this.metrics = new SqsMetricFactory();
@@ -40,8 +71,24 @@ export class SqsMonitoring extends Monitoring {
     this.oldestMessageAgeMetric = this.metrics.metricAgeOfOldestMessageInSeconds(props.queue.queueName);
     this.messageSizeMetric = this.metrics.metricAverageMessageSizeInBytes(props.queue.queueName);
 
-    this.countAnnotations = [];
-    this.ageAnnotations = [];
+    this.lowCountAlarms = this.alarmFactory.createAlarms(
+      'QueueSizeLow',
+      this.visibleMessagesMetric,
+      ComparisonOperator.LESS_THAN_THRESHOLD,
+      props.alarms?.alarmOnQueueSizeLow,
+    );
+    this.highCountAlarms = this.alarmFactory.createAlarms(
+      'QueueSizeHigh',
+      this.visibleMessagesMetric,
+      ComparisonOperator.GREATER_THAN_THRESHOLD,
+      props.alarms?.alarmOnQueueSizeHigh,
+    );
+    this.ageAlarms = this.alarmFactory.createAlarms(
+      'QueueOldestMessageAgeHigh',
+      this.oldestMessageAgeMetric,
+      ComparisonOperator.GREATER_THAN_THRESHOLD,
+      props.alarms?.alarmOnQueueOldestMessageAgeHigh,
+    );
   }
 
   getWidgets(): IWidget[] {
@@ -64,7 +111,7 @@ export class SqsMonitoring extends Monitoring {
       title: 'Message Count',
       left: [this.visibleMessagesMetric, this.incomingMessagesMetric],
       leftYAxis: CountAxis,
-      leftAnnotations: this.countAnnotations,
+      leftAnnotations: [...this.lowCountAlarms.map(a => a.annotation), ...this.highCountAlarms.map(a => a.annotation)],
     });
   }
 
@@ -75,7 +122,7 @@ export class SqsMonitoring extends Monitoring {
       title: 'Oldest Message Age',
       left: [this.oldestMessageAgeMetric],
       leftYAxis: TimeSecondsAxis,
-      leftAnnotations: this.ageAnnotations,
+      leftAnnotations: [...this.ageAlarms.map(a => a.annotation)],
     });
   }
 
@@ -93,7 +140,6 @@ export class SqsMonitoring extends Monitoring {
     return {
       titleMarkdown: `SQS Queue **${props.queue.queueName}**`,
       quicklinks: this.headerQuickLinks(props),
-      ...props,
     };
   }
 

--- a/test/monitoring/aws/sqs/__snapshots__/monitoring.test.ts.snap
+++ b/test/monitoring/aws/sqs/__snapshots__/monitoring.test.ts.snap
@@ -1,6 +1,377 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshot test 1`] = `
+exports[`snapshot test: widgets and resources, all alarms 1`] = `
+Array [
+  Object {
+    "height": 2,
+    "markdown": Object {
+      "Fn::Join": Array [
+        "",
+        Array [
+          "# SQS Queue **",
+          Object {
+            "Fn::GetAtt": Array [
+              "Queue4A7E3555",
+              "QueueName",
+            ],
+          },
+          "**
+
+[button:Overview](https://",
+          Object {
+            "Ref": "AWS::Region",
+          },
+          ".console.aws.amazon.com/sqs/v2/home?region=",
+          Object {
+            "Ref": "AWS::Region",
+          },
+          "#/queues/",
+          Object {
+            "Ref": "Queue4A7E3555",
+          },
+          ")",
+        ],
+      ],
+    },
+    "width": 24,
+  },
+  Object {
+    "height": 5,
+    "leftMetrics": Array [
+      Object {
+        "dimensions": Object {
+          "QueueName": Object {
+            "Fn::GetAtt": Array [
+              "Queue4A7E3555",
+              "QueueName",
+            ],
+          },
+        },
+        "metricName": "ApproximateNumberOfMessagesVisible",
+        "namespace": "AWS/SQS",
+        "period": Object {
+          "amount": 5,
+          "unit": Object {
+            "inMillis": 60000,
+            "isoLabel": "M",
+            "label": "minutes",
+          },
+        },
+        "statistic": "Maximum",
+      },
+      Object {
+        "dimensions": Object {
+          "QueueName": Object {
+            "Fn::GetAtt": Array [
+              "Queue4A7E3555",
+              "QueueName",
+            ],
+          },
+        },
+        "metricName": "NumberOfMessagesSent",
+        "namespace": "AWS/SQS",
+        "period": Object {
+          "amount": 5,
+          "unit": Object {
+            "inMillis": 60000,
+            "isoLabel": "M",
+            "label": "minutes",
+          },
+        },
+        "statistic": "Sum",
+      },
+    ],
+    "props": Object {
+      "height": 5,
+      "left": Array [
+        Object {
+          "dimensions": Object {
+            "QueueName": Object {
+              "Fn::GetAtt": Array [
+                "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+          "metricName": "ApproximateNumberOfMessagesVisible",
+          "namespace": "AWS/SQS",
+          "period": Object {
+            "amount": 5,
+            "unit": Object {
+              "inMillis": 60000,
+              "isoLabel": "M",
+              "label": "minutes",
+            },
+          },
+          "statistic": "Maximum",
+        },
+        Object {
+          "dimensions": Object {
+            "QueueName": Object {
+              "Fn::GetAtt": Array [
+                "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+          "metricName": "NumberOfMessagesSent",
+          "namespace": "AWS/SQS",
+          "period": Object {
+            "amount": 5,
+            "unit": Object {
+              "inMillis": 60000,
+              "isoLabel": "M",
+              "label": "minutes",
+            },
+          },
+          "statistic": "Sum",
+        },
+      ],
+      "leftAnnotations": Array [
+        Object {
+          "label": "ApproximateNumberOfMessagesVisible < 20 for 1 datapoints within 5 minutes",
+          "value": 20,
+        },
+        Object {
+          "label": "ApproximateNumberOfMessagesVisible > 30 for 1 datapoints within 5 minutes",
+          "value": 30,
+        },
+      ],
+      "leftYAxis": Object {
+        "min": 0,
+        "showUnits": false,
+      },
+      "title": "Message Count",
+      "width": 8,
+    },
+    "rightMetrics": Array [],
+    "width": 8,
+  },
+  Object {
+    "height": 5,
+    "leftMetrics": Array [
+      Object {
+        "dimensions": Object {
+          "QueueName": Object {
+            "Fn::GetAtt": Array [
+              "Queue4A7E3555",
+              "QueueName",
+            ],
+          },
+        },
+        "metricName": "ApproximateAgeOfOldestMessage",
+        "namespace": "AWS/SQS",
+        "period": Object {
+          "amount": 5,
+          "unit": Object {
+            "inMillis": 60000,
+            "isoLabel": "M",
+            "label": "minutes",
+          },
+        },
+        "statistic": "Maximum",
+      },
+    ],
+    "props": Object {
+      "height": 5,
+      "left": Array [
+        Object {
+          "dimensions": Object {
+            "QueueName": Object {
+              "Fn::GetAtt": Array [
+                "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+          "metricName": "ApproximateAgeOfOldestMessage",
+          "namespace": "AWS/SQS",
+          "period": Object {
+            "amount": 5,
+            "unit": Object {
+              "inMillis": 60000,
+              "isoLabel": "M",
+              "label": "minutes",
+            },
+          },
+          "statistic": "Maximum",
+        },
+      ],
+      "leftAnnotations": Array [
+        Object {
+          "label": "ApproximateAgeOfOldestMessage > 10 for 1 datapoints within 5 minutes",
+          "value": 10,
+        },
+      ],
+      "leftYAxis": Object {
+        "label": "sec",
+        "min": 0,
+        "showUnits": false,
+      },
+      "title": "Oldest Message Age",
+      "width": 8,
+    },
+    "rightMetrics": Array [],
+    "width": 8,
+  },
+  Object {
+    "height": 5,
+    "leftMetrics": Array [
+      Object {
+        "dimensions": Object {
+          "QueueName": Object {
+            "Fn::GetAtt": Array [
+              "Queue4A7E3555",
+              "QueueName",
+            ],
+          },
+        },
+        "metricName": "SentMessageSize",
+        "namespace": "AWS/SQS",
+        "period": Object {
+          "amount": 5,
+          "unit": Object {
+            "inMillis": 60000,
+            "isoLabel": "M",
+            "label": "minutes",
+          },
+        },
+        "statistic": "Average",
+      },
+    ],
+    "props": Object {
+      "height": 5,
+      "left": Array [
+        Object {
+          "dimensions": Object {
+            "QueueName": Object {
+              "Fn::GetAtt": Array [
+                "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+          "metricName": "SentMessageSize",
+          "namespace": "AWS/SQS",
+          "period": Object {
+            "amount": 5,
+            "unit": Object {
+              "inMillis": 60000,
+              "isoLabel": "M",
+              "label": "minutes",
+            },
+          },
+          "statistic": "Average",
+        },
+      ],
+      "leftYAxis": Object {
+        "label": "bytes",
+        "min": 0,
+        "showUnits": false,
+      },
+      "title": "Message Size",
+      "width": 8,
+    },
+    "rightMetrics": Array [],
+    "width": 8,
+  },
+]
+`;
+
+exports[`snapshot test: widgets and resources, all alarms 2`] = `
+Object {
+  "Resources": Object {
+    "AlarmsTestQueueOldestMessageAgeHighDummyDB161447": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AlarmsTestQueueSizeHighDummy0A9FF5B6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 30,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "AlarmsTestQueueSizeLowDummyE12D05BB": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 1,
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 20,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Queue4A7E3555": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "QueueName": "DummyQueueName",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
+`;
+
+exports[`snapshot test: widgets and resources, no alarms 1`] = `
 Array [
   Object {
     "height": 2,
@@ -262,4 +633,19 @@ Array [
     "width": 8,
   },
 ]
+`;
+
+exports[`snapshot test: widgets and resources, no alarms 2`] = `
+Object {
+  "Resources": Object {
+    "Queue4A7E3555": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "QueueName": "DummyQueueName",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+}
 `;

--- a/test/monitoring/aws/sqs/monitoring.test.ts
+++ b/test/monitoring/aws/sqs/monitoring.test.ts
@@ -1,11 +1,43 @@
+import { SynthUtils } from '@aws-cdk/assert';
 import { Queue } from '@aws-cdk/aws-sqs';
 import { Stack } from '@aws-cdk/core';
-import { SqsMonitoring } from '../../../../src/monitoring/aws/sqs/monitoring';
+import { DefaultAlarmFactory } from '../../../../src/core/alarming';
+import { SqsMonitoring, SqsMonitoringAlarms } from '../../../../src/monitoring/aws/sqs/monitoring';
 
-test('snapshot test', () => {
+test('snapshot test: widgets and resources, no alarms', () => {
   // GIVEN
+
   const resources = createTestResources();
-  const unitToTest = new SqsMonitoring({ queue: resources.queue });
+  const unitToTest = new SqsMonitoring({ queue: resources.queue, alarmFactory: resources.alarms });
+
+  // WHEN
+
+  const widgets = unitToTest.getWidgets();
+  const resolvedWidgets = resources.stack.resolve(widgets);
+
+  // THEN
+
+  expect(resolvedWidgets).toMatchSnapshot();
+  expect(SynthUtils.toCloudFormation(resources.stack)).toMatchSnapshot();
+});
+
+test('snapshot test: widgets and resources, all alarms', () => {
+  // GIVEN
+
+  const alarms: SqsMonitoringAlarms = {
+    alarmOnQueueOldestMessageAgeHigh: {
+      Dummy: { threshold: 10 },
+    },
+    alarmOnQueueSizeLow: {
+      Dummy: { threshold: 20 },
+    },
+    alarmOnQueueSizeHigh: {
+      Dummy: { threshold: 30 },
+    },
+  };
+
+  const resources = createTestResources();
+  const unitToTest = new SqsMonitoring({ queue: resources.queue, alarmFactory: resources.alarms, alarms });
 
   // WHEN
   const widgets = unitToTest.getWidgets();
@@ -13,10 +45,17 @@ test('snapshot test', () => {
 
   // THEN
   expect(resolvedWidgets).toMatchSnapshot();
+  expect(SynthUtils.toCloudFormation(resources.stack)).toMatchSnapshot();
 });
 
 function createTestResources() {
   const stack = new Stack();
   const queue = new Queue(stack, 'Queue', { queueName: 'DummyQueueName' });
-  return { stack, queue };
+  const alarms = new DefaultAlarmFactory(stack, 'Alarms', {
+    prefix: 'Test',
+    evaluationPeriodsDefault: 1,
+    datapointsToAlarmDefault: 1,
+    actionsEnabledDefault: true,
+  });
+  return { stack, queue, alarms };
 }


### PR DESCRIPTION
This PR is the first one to add support for alarms. I will try to elaborate a bit on the design.

* First of all, the alarm creation itself has been encapsulated into an `AlarmFactory`. This is to allow backwards compatibility for existing Watchful users and possibility to add an internal alarm factory implementation with proprietary logic (ticket cutting at Amazon).
* The alarm definition itself had to be changed
  *  alarm definition on the **monitoring** level is fully custom, so there are no automatical "out-of-the-box" alarms created; this is expected to happen at an optional higher layer, e.g. in each `Watcher`
  * multiple alarms can be defined on each metric, so the user can e.g. define Warning and Critical alarms with different thresholds
  * high amount of customization is added to each alarm, so the user can control all the details of the alarm, e.g. number of datapoints, later also a period, and so on
  *  disambiguator is added to make each alarm distinct and give more context to the alarm, e.g. how serious it is