### PR TITLE
fix: Updated succeeded metric label for StateMachineMetrics

### DIFF
--- a/src/monitoring/aws/state-machine/metrics.ts
+++ b/src/monitoring/aws/state-machine/metrics.ts
@@ -16,7 +16,7 @@ export class StateMachineMetricFactory {
   metricExecutions(stateMachineArn: string) {
     return {
       total: this.metric(Metrics.ExecutionsStarted, stateMachineArn).with({ label: 'Total', statistic: Statistic.SUM }),
-      succeeded: this.metric(Metrics.ExecutionsSucceeded, stateMachineArn).with({ label: 'Failed Succeeded', statistic: Statistic.SUM }),
+      succeeded: this.metric(Metrics.ExecutionsSucceeded, stateMachineArn).with({ label: 'Executions Succeeded', statistic: Statistic.SUM }),
       failed: this.metric(Metrics.ExecutionsFailed, stateMachineArn).with({ label: 'Failed Executions', statistic: Statistic.SUM }),
       aborted: this.metric(Metrics.ExecutionsAborted, stateMachineArn).with({ label: 'Aborted Executions', statistic: Statistic.SUM }),
       throttled: this.metric(Metrics.ExecutionThrottled, stateMachineArn).with({ label: 'Executions Throttled', statistic: Statistic.SUM }),

--- a/test/monitoring/aws/state-machine/__snapshots__/metrics.test.ts.snap
+++ b/test/monitoring/aws/state-machine/__snapshots__/metrics.test.ts.snap
@@ -50,7 +50,7 @@ Object {
     "dimensions": Object {
       "StateMachineArn": "dummy-state-machine-arn",
     },
-    "label": "Failed Succeeded",
+    "label": "Executions Succeeded",
     "metricName": "ExecutionsSucceeded",
     "namespace": "AWS/States",
     "period": Duration {


### PR DESCRIPTION
Fixes #
 - fix: Removed "Failed" from Succeeded metric label