### PR TITLE
feat(ECS): Added support for fargate service

### DIFF
--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -1,7 +1,9 @@
 import { IAspect } from 'aws-cdk-lib';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as ecs_patterns from 'aws-cdk-lib/aws-ecs-patterns';
+import * as elasticLoadBalancing from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
@@ -99,8 +101,16 @@ export class WatchfulAspect implements IAspect {
       this.watchful.watchFargateEcs(node.node.path, node.service, node.targetGroup);
     }
 
+    if (watchFargateEcs && node instanceof ecs.FargateService) {
+      this.watchful.watchFargateService(node.node.path, node);
+    }
+
     if (watchEc2Ecs && node instanceof ecs_patterns.ApplicationLoadBalancedEc2Service) {
       this.watchful.watchEc2Ecs(node.node.path, node.service, node.targetGroup);
+    }
+
+    if (watchEc2Ecs && node instanceof elasticLoadBalancing.ApplicationTargetGroup) {
+      this.watchful.watchApplicationTargetGroup(node.node.path, node);
     }
   }
 }

--- a/src/ecs/index.ts
+++ b/src/ecs/index.ts
@@ -1,0 +1,92 @@
+import { Names } from 'aws-cdk-lib';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import { ApplicationTargetGroup } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Construct } from 'constructs';
+import { IWatchful } from '../api';
+import { linkForEcsService, WatchService } from './service';
+import { WatchTargetGroup } from './target-group';
+
+export * from './target-group';
+export * from './service';
+
+
+export interface WatchEcsServiceOptions {
+  /**
+     * Threshold for the Cpu Maximum utilization
+     *
+     * @default 80
+     */
+  readonly cpuMaximumThresholdPercent?: number;
+
+  /**
+   * Threshold for the Memory Maximum utilization.
+   *
+   * @default - 0.
+   */
+  readonly memoryMaximumThresholdPercent?: number;
+
+  /**
+   * Threshold for the Target Response Time.
+   *
+   * @default - 0.
+   */
+  readonly targetResponseTimeThreshold?: number;
+
+  /**
+   * Threshold for the Number of Requests.
+   *
+   * @default - 0.
+   */
+  readonly requestsThreshold?: number;
+
+  /**
+   * Threshold for the Number of Request Errors.
+   *
+   * @default - 0.
+   */
+  readonly requestsErrorRateThreshold?: number;
+}
+
+export interface WatchEcsServiceProps extends WatchEcsServiceOptions {
+  readonly title: string;
+  readonly watchful: IWatchful;
+  readonly fargateService?: ecs.FargateService;
+  readonly ec2Service?: ecs.Ec2Service;
+  readonly targetGroup: ApplicationTargetGroup;
+}
+
+export class WatchEcsService extends Construct {
+
+  private readonly watchful: IWatchful;
+  private readonly ecsService: ecs.BaseService;
+
+  constructor(scope: Construct, id: string, props: WatchEcsServiceProps) {
+    super(scope, id);
+
+    this.watchful = props.watchful;
+
+    if (!props.ec2Service || !props.fargateService) {
+      throw new Error('No service provided to monitor.');
+    };
+
+    this.ecsService = props.ec2Service ?? props.fargateService;
+
+    this.watchful.addSection(props.title, {
+      links: [
+        { title: 'ECS Service', url: linkForEcsService(this.ecsService) },
+      ],
+    });
+
+    new WatchService(this, Names.uniqueId(this.ecsService), {
+      ...props,
+      service: this.ecsService,
+      skipLinkSection: true,
+    });
+
+    new WatchTargetGroup(this, Names.uniqueId(props.targetGroup), {
+      ...props,
+      skipLinkSection: true,
+    });
+  }
+
+}

--- a/src/ecs/service.ts
+++ b/src/ecs/service.ts
@@ -1,0 +1,98 @@
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import { Construct } from 'constructs';
+import { IWatchful } from '../api';
+import { WatchEcsServiceOptions } from '../ecs';
+import { EcsMetricFactory } from '../monitoring/aws/ecs/metrics';
+
+
+export interface WatchServiceProps extends WatchEcsServiceOptions {
+  readonly title: string;
+  readonly watchful: IWatchful;
+  readonly service: ecs.BaseService;
+  /**
+   * Whether to add link section at the start of widget
+   * @default - false
+   */
+  readonly skipLinkSection?: boolean;
+}
+
+export class WatchService extends Construct {
+
+  private readonly watchful: IWatchful;
+  private readonly ecsService: any;
+  private readonly serviceName: string;
+  private readonly clusterName: string;
+  private readonly metrics: EcsMetricFactory;
+
+  constructor(scope: Construct, id: string, props: WatchServiceProps) {
+    super(scope, id);
+
+    this.watchful = props.watchful;
+
+    this.ecsService = props.service;
+    this.serviceName = props.service.serviceName;
+    this.clusterName = props.service.cluster.clusterName;
+
+
+    this.metrics = new EcsMetricFactory();
+
+    const skipLinkSection = props.skipLinkSection ?? false;
+
+    if (!skipLinkSection) {
+      this.watchful.addSection(props.title, {
+        links: [
+          { title: 'ECS Service', url: linkForEcsService(this.ecsService) },
+        ],
+      });
+    }
+
+    const { cpuUtilizationMetric, cpuUtilizationAlarm } = this.createCpuUtilizationMonitor(props.cpuMaximumThresholdPercent);
+    const { memoryUtilizationMetric, memoryUtilizationAlarm } = this.createMemoryUtilizationMonitor(props.memoryMaximumThresholdPercent);
+
+
+    this.watchful.addWidgets(
+      new cloudwatch.GraphWidget({
+        title: `CPUUtilization/${cpuUtilizationMetric.period.toMinutes()}min`,
+        width: 12,
+        left: [cpuUtilizationMetric],
+        leftAnnotations: [cpuUtilizationAlarm.toAnnotation()],
+      }),
+      new cloudwatch.GraphWidget({
+        title: `MemoryUtilization/${memoryUtilizationMetric.period.toMinutes()}min`,
+        width: 12,
+        left: [memoryUtilizationMetric],
+        leftAnnotations: [memoryUtilizationAlarm.toAnnotation()],
+      }),
+    );
+  }
+
+  private createCpuUtilizationMonitor(cpuMaximumThresholdPercent = 0) {
+    const cpuUtilizationMetric = this.metrics.metricCpuUtilizationAverage(this.clusterName, this.serviceName);
+    const cpuUtilizationAlarm = cpuUtilizationMetric.createAlarm(this, 'cpuUtilizationAlarm', {
+      alarmDescription: 'cpuUtilizationAlarm',
+      threshold: cpuMaximumThresholdPercent,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 3,
+    });
+    this.watchful.addAlarm(cpuUtilizationAlarm);
+    return { cpuUtilizationMetric, cpuUtilizationAlarm };
+  }
+
+  private createMemoryUtilizationMonitor(memoryMaximumThresholdPercent = 0) {
+    const memoryUtilizationMetric = this.metrics.metricMemoryUtilizationAverage(this.clusterName, this.serviceName);
+    const memoryUtilizationAlarm = memoryUtilizationMetric.createAlarm(this, 'memoryUtilizationAlarm', {
+      alarmDescription: 'memoryUtilizationAlarm',
+      threshold: memoryMaximumThresholdPercent,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 3,
+    });
+    this.watchful.addAlarm(memoryUtilizationAlarm);
+    return { memoryUtilizationMetric, memoryUtilizationAlarm };
+  }
+
+}
+
+export function linkForEcsService(ecsService: any) {
+  return `https://console.aws.amazon.com/ecs/home?region=${ecsService.stack.region}#/clusters/${ecsService.cluster.clusterName}/services/${ecsService.serviceName}/details`;
+}

--- a/src/watchful.ts
+++ b/src/watchful.ts
@@ -4,7 +4,7 @@ import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as cloudwatch_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
-import { ApplicationTargetGroup } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { ApplicationTargetGroup, TargetGroupBase } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as sns from 'aws-cdk-lib/aws-sns';
@@ -17,6 +17,8 @@ import { WatchApiGatewayOptions, WatchApiGateway } from './api-gateway';
 import { WatchfulAspect, WatchfulAspectProps } from './aspect';
 import { WatchDynamoTableOptions, WatchDynamoTable } from './dynamodb';
 import { WatchEcsServiceOptions, WatchEcsService } from './ecs';
+import { WatchService } from './ecs/service';
+import { WatchTargetGroup } from './ecs/target-group';
 import { WatchLambdaFunctionOptions, WatchLambdaFunction } from './lambda';
 import { WatchRdsAuroraOptions, WatchRdsAurora } from './rds-aurora';
 import { WatchStateMachineOptions, WatchStateMachine } from './state-machine';
@@ -190,6 +192,16 @@ export class Watchful extends Construct implements IWatchful {
   public watchEc2Ecs(title: string, ec2Service: ecs.Ec2Service, targetGroup: ApplicationTargetGroup, options: WatchEcsServiceOptions = {}) {
     return new WatchEcsService(this, Names.uniqueId(ec2Service), {
       title, watchful: this, ec2Service, targetGroup, ...options,
+    });
+  }
+  public watchFargateService(title: string, service: ecs.FargateService, options: WatchEcsServiceOptions = {}) {
+    return new WatchService(this, Names.uniqueId(service), {
+      title, watchful: this, service, ...options,
+    });
+  }
+  public watchApplicationTargetGroup(title: string, targetGroup: TargetGroupBase, options: WatchEcsServiceOptions = {}) {
+    return new WatchTargetGroup(this, Names.uniqueId(targetGroup), {
+      title, watchful: this, targetGroup, ...options,
     });
   }
 }


### PR DESCRIPTION
- Split the logic of watchECS into watching the service and watching the Target Group 
- Added support for monitoring fargate services and target groups that are created separately and not via `ApplicationLoadBalancedFargateService`